### PR TITLE
CFD-I5 Update cancel notification to send to annette

### DIFF
--- a/src/routes/subscription.js
+++ b/src/routes/subscription.js
@@ -4,6 +4,7 @@ import { Subscription } from "../database/Subscription"
 import { UserCard } from "../database/UserCard"
 import { Transaction } from "../database/Transaction"
 import toggleSubscription from "../utils/toggleSubscription"
+import sendEmail from "@/utils/sendEmail"
 
 const router = express.Router()
 
@@ -130,7 +131,7 @@ router.post("/cancel/:subscription_id", authMiddleware(null, { allowSelf: true }
 
         // send email to annette
         await sendEmail({
-          to: email,
+          to: "annette@remrktco.com",
           subject: "Subscription Set to Cancel",
           text: ``,
           template: "subscriptionCancelled.html",


### PR DESCRIPTION
[CFD-I5](https://sprints.zoho.com/workspace/dbmgrow#P3/itemdetails/I5)

Looks like this was always supposed to be a feature, but we didn't have the right email in place — should always send to annette. The variable "email" actually doesn't exist here so I'm suprised this wasn't caught earlier 