### PR TITLE
hotfix(#1475): resume cancelled/suspended subscription on user.activated

### DIFF
--- a/api/application/webhook-handlers/cashoffers-webhook.handler.ts
+++ b/api/application/webhook-handlers/cashoffers-webhook.handler.ts
@@ -26,7 +26,7 @@ type WebhookEvent =
  *
  * Processes incoming webhook events from the CashOffers main API:
  * - user.deactivated → pause user's active subscription
- * - user.activated → resume user's suspended subscription (with renewal date adjustment)
+ * - user.activated → resume user's most recent paused/suspended/cancelled subscription (with renewal date adjustment)
  * - user.created (free user) → create free trial subscription
  */
 export class CashOffersWebhookHandler {
@@ -64,32 +64,65 @@ export class CashOffersWebhookHandler {
     }
   }
 
+  // Statuses a reactivation is allowed to resume. We resume not just 'paused'
+  // (set by handleUserDeactivated) but also 'suspended' (terminal dunning) and
+  // 'cancelled' (e.g. trial expiry — see subscriptionsCron). Previously only
+  // 'paused' was handled, so a user who signed back up with a cancelled/suspended
+  // subscription was left premium-in-UI but with no active sub, and the renewal
+  // cron (active-only) never charged them again — ticket #1475.
+  private static readonly RESUMABLE_STATUSES = new Set(['paused', 'suspended', 'cancelled'])
+
   private async handleUserActivated(userId: number): Promise<void> {
-    const { subscriptionRepository } = this.deps
+    const { subscriptionRepository, logger } = this.deps
     const subscriptions = await subscriptionRepository.findByUserId(userId)
 
-    const suspended = subscriptions.filter((s) => s.status === 'paused')
-    for (const sub of suspended) {
-      const now = new Date()
-      let newRenewalDate = sub.renewal_date ? new Date(sub.renewal_date) : now
+    // Idempotency / safety: if the user already has a live subscription, there is
+    // nothing to resume — and resuming another row on top would double-bill.
+    if (subscriptions.some((s) => s.status === 'active' || s.status === 'trial')) return
 
-      if (sub.suspension_date && sub.renewal_date) {
-        const suspensionDate = new Date(sub.suspension_date)
-        const originalRenewalDate = new Date(sub.renewal_date)
-        const daysRemaining = Math.round(
-          (originalRenewalDate.getTime() - suspensionDate.getTime()) / (1000 * 60 * 60 * 24)
-        )
-        newRenewalDate = new Date(now)
-        newRenewalDate.setDate(now.getDate() + daysRemaining)
-      }
+    // Resume only the most recent resumable subscription (highest subscription_id).
+    // A user may carry old cancelled rows from prior plans; reviving all of them
+    // would create duplicate active subscriptions and duplicate charges.
+    const sub = subscriptions
+      .filter((s) => CashOffersWebhookHandler.RESUMABLE_STATUSES.has(s.status ?? ''))
+      .sort((a, b) => (b.subscription_id ?? 0) - (a.subscription_id ?? 0))[0]
+    if (!sub) return
 
-      await subscriptionRepository.update(sub.subscription_id, {
-        status: 'active',
-        suspension_date: null,
-        renewal_date: newRenewalDate,
-        updatedAt: now,
-      } as any)
+    const now = new Date()
+    let newRenewalDate = sub.renewal_date ? new Date(sub.renewal_date) : now
+
+    if (sub.suspension_date && sub.renewal_date) {
+      const suspensionDate = new Date(sub.suspension_date)
+      const originalRenewalDate = new Date(sub.renewal_date)
+      const daysRemaining = Math.round(
+        (originalRenewalDate.getTime() - suspensionDate.getTime()) / (1000 * 60 * 60 * 24)
+      )
+      newRenewalDate = new Date(now)
+      newRenewalDate.setDate(now.getDate() + daysRemaining)
     }
+
+    // Never resume with a renewal date in the past. A long-dead subscription
+    // (e.g. cancelled a year ago) would otherwise be charged immediately and then,
+    // since the cron advances from the stale date, charged repeatedly to "catch up"
+    // on every missed cycle. Clamp to now so the user is billed for the new period
+    // going forward, once.
+    if (newRenewalDate.getTime() < now.getTime()) {
+      newRenewalDate = now
+    }
+
+    await subscriptionRepository.update(sub.subscription_id, {
+      status: 'active',
+      suspension_date: null,
+      renewal_date: newRenewalDate,
+      updatedAt: now,
+    } as any)
+
+    logger.info('Resumed subscription on user.activated', {
+      userId,
+      subscriptionId: sub.subscription_id,
+      previousStatus: sub.status,
+      renewalDate: newRenewalDate,
+    })
   }
 
   private async handleUserCreated(userId: number): Promise<void> {

--- a/api/tests/integration/webhook-cashoffers-reactivation.test.ts
+++ b/api/tests/integration/webhook-cashoffers-reactivation.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression test — Zoho Desk ticket #1475
+ * "YHS Agent signed back up but payment did not come out"
+ *
+ * Real-world symptom (prod user 967, agent "Sharad Gupta", whitelabel YHS):
+ *   - Subscription 128 was suspended/cancelled (status='cancelled') on 2025-04-01.
+ *   - Agent later "signed back up" and updated his card, but NO recurring charge
+ *     came out in the following months.
+ *
+ * Root cause: when a user is reactivated, the main API emits a `user.activated`
+ * webhook. CashOffersWebhookHandler.handleUserActivated originally only resumed
+ * subscriptions whose status === 'paused'. A subscription left in 'cancelled' (or
+ * 'suspended') state was never flipped back to 'active', so the renewal cron —
+ * which selects only status='active' rows — never charged it. The agent showed
+ * premium/active in the UI but was never billed.
+ *
+ * Fix: handleUserActivated now resumes the most recent paused/suspended/cancelled
+ * subscription (guarding against an already-active sub and past renewal dates).
+ * These tests lock in that behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { InMemoryEventBus } from '@api/infrastructure/events/in-memory-event-bus'
+import {
+  makeLogger,
+  makeUserApiClient,
+  makeSubscriptionRepository,
+  makeSubscriptionRow,
+} from './helpers/test-doubles'
+import { CashOffersWebhookHandler } from '@api/application/webhook-handlers/cashoffers-webhook.handler'
+
+describe('CashOffersWebhookHandler — reactivation of a non-paused subscription (ticket #1475)', () => {
+  const userId = 967
+  const subscriptionId = 128
+
+  let logger: ReturnType<typeof makeLogger>
+  let userApiClient: ReturnType<typeof makeUserApiClient>
+  let subscriptionRepository: ReturnType<typeof makeSubscriptionRepository>
+  let eventBus: InMemoryEventBus
+  let handler: CashOffersWebhookHandler
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    logger = makeLogger()
+    userApiClient = makeUserApiClient()
+    subscriptionRepository = makeSubscriptionRepository()
+    eventBus = new InMemoryEventBus(logger)
+
+    handler = new CashOffersWebhookHandler({
+      logger,
+      userApiClient,
+      subscriptionRepository: subscriptionRepository as any,
+      eventBus,
+    })
+  })
+
+  it('resumes a CANCELLED subscription when the user is reactivated', async () => {
+    // Exactly the prod state: subscription left 'cancelled' after suspension.
+    subscriptionRepository.findByUserId.mockResolvedValue([
+      makeSubscriptionRow({
+        subscription_id: subscriptionId,
+        user_id: userId,
+        status: 'cancelled',
+        suspension_date: new Date('2025-04-01'),
+        renewal_date: new Date('2025-04-01'),
+      }),
+    ])
+
+    await handler.handle({ type: 'user.activated', userId })
+
+    // Desired: the cancelled subscription is flipped back to 'active' so the
+    // renewal cron will charge it again. Today the handler ignores it.
+    const updateCalls = (subscriptionRepository.update as ReturnType<typeof vi.fn>).mock.calls
+    const resumeCall = updateCalls.find((c) => c[1]?.status === 'active')
+    expect(resumeCall).toBeDefined()
+  })
+
+  it('resumes a SUSPENDED subscription when the user is reactivated', async () => {
+    // The doc comment promises "resume user's suspended subscription", but the
+    // code only matches 'paused'. A 'suspended' row is silently skipped too.
+    subscriptionRepository.findByUserId.mockResolvedValue([
+      makeSubscriptionRow({
+        subscription_id: subscriptionId,
+        user_id: userId,
+        status: 'suspended',
+        suspension_date: new Date('2025-04-01'),
+        renewal_date: new Date('2025-04-01'),
+      }),
+    ])
+
+    await handler.handle({ type: 'user.activated', userId })
+
+    const updateCalls = (subscriptionRepository.update as ReturnType<typeof vi.fn>).mock.calls
+    const resumeCall = updateCalls.find((c) => c[1]?.status === 'active')
+    expect(resumeCall).toBeDefined()
+  })
+})

--- a/api/tests/integration/webhook-cashoffers-reactivation.test.ts
+++ b/api/tests/integration/webhook-cashoffers-reactivation.test.ts
@@ -66,6 +66,7 @@ describe('CashOffersWebhookHandler — reactivation of a non-paused subscription
       }),
     ])
 
+    const before = Date.now()
     await handler.handle({ type: 'user.activated', userId })
 
     // Desired: the cancelled subscription is flipped back to 'active' so the
@@ -73,6 +74,17 @@ describe('CashOffersWebhookHandler — reactivation of a non-paused subscription
     const updateCalls = (subscriptionRepository.update as ReturnType<typeof vi.fn>).mock.calls
     const resumeCall = updateCalls.find((c) => c[1]?.status === 'active')
     expect(resumeCall).toBeDefined()
+    // ...and on the correct row.
+    expect(resumeCall?.[0]).toBe(subscriptionId)
+
+    // Past-date clamp: the original renewal_date (2025-04-01) is long gone. It must
+    // be clamped to ~now, NOT carried forward as a stale date — otherwise the cron
+    // would bill the user immediately and then repeatedly "catch up" every missed
+    // cycle from the 2025 date. Bill forward once, going forward.
+    const renewalDate: Date = resumeCall?.[1]?.renewal_date
+    expect(renewalDate).toBeInstanceOf(Date)
+    expect(renewalDate.getTime()).toBeGreaterThanOrEqual(before)
+    expect(renewalDate.getTime()).toBeGreaterThan(new Date('2025-04-01').getTime())
   })
 
   it('resumes a SUSPENDED subscription when the user is reactivated', async () => {
@@ -93,5 +105,54 @@ describe('CashOffersWebhookHandler — reactivation of a non-paused subscription
     const updateCalls = (subscriptionRepository.update as ReturnType<typeof vi.fn>).mock.calls
     const resumeCall = updateCalls.find((c) => c[1]?.status === 'active')
     expect(resumeCall).toBeDefined()
+  })
+
+  it('resumes ONLY the most recent resumable subscription, not stale older rows', async () => {
+    // A user can carry old cancelled rows from prior plans. Reviving all of them
+    // would create duplicate active subscriptions and duplicate charges, so the
+    // handler must resume only the highest subscription_id.
+    subscriptionRepository.findByUserId.mockResolvedValue([
+      makeSubscriptionRow({
+        subscription_id: 100,
+        user_id: userId,
+        status: 'cancelled',
+        suspension_date: new Date('2024-01-01'),
+        renewal_date: new Date('2024-01-01'),
+      }),
+      makeSubscriptionRow({
+        subscription_id: subscriptionId, // 128 — most recent
+        user_id: userId,
+        status: 'cancelled',
+        suspension_date: new Date('2025-04-01'),
+        renewal_date: new Date('2025-04-01'),
+      }),
+    ])
+
+    await handler.handle({ type: 'user.activated', userId })
+
+    // Exactly one resume, and it targets the newest row — never the stale id 100.
+    const updateCalls = (subscriptionRepository.update as ReturnType<typeof vi.fn>).mock.calls
+    const resumeCalls = updateCalls.filter((c) => c[1]?.status === 'active')
+    expect(resumeCalls).toHaveLength(1)
+    expect(resumeCalls[0][0]).toBe(subscriptionId)
+  })
+
+  it('does NOT resume anything when the user already has a live subscription', async () => {
+    // Idempotency / no-double-bill: an existing active (or trial) sub means there is
+    // nothing to resume — reviving another row on top would charge the user twice.
+    subscriptionRepository.findByUserId.mockResolvedValue([
+      makeSubscriptionRow({ subscription_id: 200, user_id: userId, status: 'active' }),
+      makeSubscriptionRow({
+        subscription_id: subscriptionId,
+        user_id: userId,
+        status: 'cancelled',
+        suspension_date: new Date('2025-04-01'),
+        renewal_date: new Date('2025-04-01'),
+      }),
+    ])
+
+    await handler.handle({ type: 'user.activated', userId })
+
+    expect(subscriptionRepository.update).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Ticket
#1475 — "YHS Agent signed back up but payment did not come out"

Prod user 967 (agent Sharad Gupta, YHS): last charge 2025‑03, then nothing in April/May despite showing premium/active. (Companion to the earlier `hotfix(#1475): pass x-api-token header` — this addresses the *reactivation* facet.)

## Root cause
When a user is reactivated, the main API emits a `user.activated` webhook. `CashOffersWebhookHandler.handleUserActivated` only resumed subscriptions with `status === 'paused'`. A subscription left `cancelled` (e.g. trial expiry → `subscriptionsCron` sets `cancelled`) or `suspended` (terminal dunning) was never flipped back to `active`. The renewal cron selects `active` rows only, so it never charged the user again — premium in the UI, silently unbilled.

## Fix
`handleUserActivated` now resumes the most recent `paused`/`suspended`/`cancelled` subscription, with guards:
- **skip if already active/trial** — no double-billing on top of a live sub
- **most-recent only** (highest `subscription_id`) — won't revive stale rows into duplicate active subs
- **clamp past `renewal_date` to now** — a long-dead sub is billed forward once, not charged repeatedly to "catch up" on every missed cycle
- logs an info line on resume; updated the class doc comment

## Tests
- New regression test `api/tests/integration/webhook-cashoffers-reactivation.test.ts` (cancelled + suspended both resume).
- Existing webhook tests (paused / idempotent) unchanged. **13/13 pass.**
- Verified live via `yarn dev:tools`: `scenario suspended → set-state cancelled → webhook user.activated` now flips `cancelled → active`; `paused` control still works.

## Notes / follow-ups
- This resumes any most-recent non-active sub, **including one a user intentionally cancelled**. Correct for the #1475 cases (trial-expiry/dunning); if voluntary cancellations should be excluded, the cancel path needs to record intent (e.g. `cancel_reason`) and the filter check it.
- Like the original `paused` path, resume only updates the DB row — it does not emit a `SubscriptionResumed` event. Separate follow-up if downstream provisioning depends on that event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)