### PR TITLE
hotfix(#1494): skip premium downgrade for integration-managed users

### DIFF
--- a/api/application/event-handlers/email-notification.handler.test.ts
+++ b/api/application/event-handlers/email-notification.handler.test.ts
@@ -1,4 +1,14 @@
+// NOTE: This suite is `describe.skip`-ed on purpose. Statically importing the
+// handler transitively loads real `@api/*` modules (email templates,
+// BaseEventHandler) that don't resolve under the current vitest setup, so a
+// normal import throws at collection time — the same pre-existing gap that
+// red-lists this repo's other `@api`-importing tests. To keep this file from
+// failing collection, the runtime imports are deferred into `beforeEach` (which
+// never runs while skipped). The behavior documented here is proven by the live
+// A/B in PR #23 (#1494). Re-enable (drop `.skip`) once that resolution gap is
+// fixed.
 import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { EmailNotificationHandler as EmailNotificationHandlerClass } from "./email-notification.handler"
 
 // Mock module-level singletons the handler imports.
 vi.mock("@api/lib/services", () => ({
@@ -13,22 +23,24 @@ vi.mock("@api/lib/repositories", () => ({
 // Avoid rendering the full React email tree in a unit test.
 vi.mock("@react-email/render", () => ({ render: vi.fn(async () => "<html>email</html>") }))
 
-import { EmailNotificationHandler } from "./email-notification.handler"
-import { userApiClient } from "@api/lib/services"
-import { SubscriptionCancelledEvent } from "@api/domain/events/subscription-cancelled.event"
-
-const mockedGetUser = userApiClient.getUser as unknown as ReturnType<typeof vi.fn>
-
 function makeLogger() {
   return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() } as any
 }
 
-describe("EmailNotificationHandler — integration-managed downgrade email suppression (#1494)", () => {
+describe.skip("EmailNotificationHandler — integration-managed downgrade email suppression (#1494)", () => {
+  // Resolved lazily in beforeEach so a static import doesn't crash collection (see file header).
+  let EmailNotificationHandler: typeof EmailNotificationHandlerClass
+  let SubscriptionCancelledEvent: any
+  let mockedGetUser: ReturnType<typeof vi.fn>
   let emailService: { sendEmail: ReturnType<typeof vi.fn>; sendPlainEmail: ReturnType<typeof vi.fn> }
-  let handler: EmailNotificationHandler
+  let handler: EmailNotificationHandlerClass
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
+    ;({ EmailNotificationHandler } = await import("./email-notification.handler"))
+    ;({ SubscriptionCancelledEvent } = await import("@api/domain/events/subscription-cancelled.event"))
+    const { userApiClient } = await import("@api/lib/services")
+    mockedGetUser = userApiClient.getUser as unknown as ReturnType<typeof vi.fn>
     emailService = { sendEmail: vi.fn(), sendPlainEmail: vi.fn() }
     handler = new EmailNotificationHandler(emailService as any, makeLogger())
   })

--- a/api/application/event-handlers/email-notification.handler.test.ts
+++ b/api/application/event-handlers/email-notification.handler.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock module-level singletons the handler imports.
+vi.mock("@api/lib/services", () => ({
+  whitelabelResolverService: {
+    resolveForUser: vi.fn(async () => ({ name: "kw Offerings", branding: {} })),
+  },
+  userApiClient: { getUser: vi.fn() },
+}))
+vi.mock("@api/lib/repositories", () => ({
+  whitelabelRepository: { getSuspensionBehavior: vi.fn(async () => "DOWNGRADE_TO_FREE") },
+}))
+// Avoid rendering the full React email tree in a unit test.
+vi.mock("@react-email/render", () => ({ render: vi.fn(async () => "<html>email</html>") }))
+
+import { EmailNotificationHandler } from "./email-notification.handler"
+import { userApiClient } from "@api/lib/services"
+import { SubscriptionCancelledEvent } from "@api/domain/events/subscription-cancelled.event"
+
+const mockedGetUser = userApiClient.getUser as unknown as ReturnType<typeof vi.fn>
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn().mockReturnThis() } as any
+}
+
+describe("EmailNotificationHandler — integration-managed downgrade email suppression (#1494)", () => {
+  let emailService: { sendEmail: ReturnType<typeof vi.fn>; sendPlainEmail: ReturnType<typeof vi.fn> }
+  let handler: EmailNotificationHandler
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    emailService = { sendEmail: vi.fn(), sendPlainEmail: vi.fn() }
+    handler = new EmailNotificationHandler(emailService as any, makeLogger())
+  })
+
+  it("does NOT send a 'Downgraded to Free' email for an integration-managed user", async () => {
+    mockedGetUser.mockResolvedValue({ id: 26126, whitelabel_id: 2, integration_id: 1 })
+
+    await handler.handle(
+      SubscriptionCancelledEvent.create({
+        subscriptionId: 154,
+        userId: 26126,
+        email: "soldbyangelina@kw.com",
+        subscriptionName: "KW",
+        cancelOnRenewal: false,
+      })
+    )
+
+    expect(emailService.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it("DOES send the 'Downgraded to Free' email for a non-integration user", async () => {
+    mockedGetUser.mockResolvedValue({ id: 555, whitelabel_id: 2, integration_id: null })
+
+    await handler.handle(
+      SubscriptionCancelledEvent.create({
+        subscriptionId: 200,
+        userId: 555,
+        email: "b@example.com",
+        subscriptionName: "Pro",
+        cancelOnRenewal: false,
+      })
+    )
+
+    expect(emailService.sendEmail).toHaveBeenCalledTimes(1)
+    expect(emailService.sendEmail.mock.calls[0][0].subject).toMatch(/Downgraded to Free/i)
+  })
+})

--- a/api/application/event-handlers/email-notification.handler.tsx
+++ b/api/application/event-handlers/email-notification.handler.tsx
@@ -92,6 +92,27 @@ export class EmailNotificationHandler extends BaseEventHandler {
     return environment === "sandbox"
   }
 
+  /**
+   * Whether this user's plan is governed by an external integration (e.g. KW
+   * Community / Chargify). Such users must NOT receive Square billing
+   * lapse/suspension/cancellation/downgrade emails — their premium isn't
+   * controlled here, so a "downgraded to Free" notice is wrong and alarming
+   * (#1494; pairs with the UserApiClient.updateUser premium guard).
+   *
+   * On lookup failure we return false (don't suppress) — a possibly-redundant
+   * email is safer than silently dropping a legitimate one.
+   */
+  private async isIntegrationManaged(userId: number | null | undefined): Promise<boolean> {
+    if (userId == null) return false
+    try {
+      const user = await userApiClient.getUser(userId)
+      return user?.integration_id != null
+    } catch {
+      this.logger.warn("Failed to check integration_id for email suppression", { userId })
+      return false
+    }
+  }
+
   async handle(event: IDomainEvent): Promise<void> {
     switch (event.eventType) {
       case "SubscriptionCreated":
@@ -585,6 +606,14 @@ export class EmailNotificationHandler extends BaseEventHandler {
           return
         }
 
+        if (await this.isIntegrationManaged(event.payload.userId)) {
+          this.logger.info("Skipping subscription deactivated email for integration-managed user", {
+            userId: event.payload.userId,
+            subscriptionId: event.payload.subscriptionId,
+          })
+          return
+        }
+
         this.logger.info("Sending subscription deactivated email", {
           email,
           subscriptionId: event.payload.subscriptionId,
@@ -625,6 +654,14 @@ export class EmailNotificationHandler extends BaseEventHandler {
 
         if (!email) {
           this.logger.debug("No email provided for subscription pause notification", {
+            subscriptionId: event.payload.subscriptionId,
+          })
+          return
+        }
+
+        if (await this.isIntegrationManaged(event.payload.userId)) {
+          this.logger.info("Skipping subscription paused email for integration-managed user", {
+            userId: event.payload.userId,
             subscriptionId: event.payload.subscriptionId,
           })
           return
@@ -680,6 +717,17 @@ export class EmailNotificationHandler extends BaseEventHandler {
         let suspensionStrategy: string | undefined
         try {
           const user = await userApiClient.getUser(userId)
+          // Integration-managed users (e.g. KW Community/Chargify) are governed by an
+          // external integration — don't send them Square cancel/downgrade emails. The
+          // premium itself is already protected in UserApiClient.updateUser. (#1494)
+          if (user?.integration_id != null) {
+            this.logger.info("Skipping subscription cancellation/downgrade email for integration-managed user", {
+              userId,
+              subscriptionId: event.payload.subscriptionId,
+              integrationId: user.integration_id,
+            })
+            return
+          }
           if (user?.whitelabel_id) {
             const behavior = await whitelabelRepository.getSuspensionBehavior(user.whitelabel_id)
             if (behavior) suspensionStrategy = behavior
@@ -801,6 +849,14 @@ export class EmailNotificationHandler extends BaseEventHandler {
 
         if (!email) {
           this.logger.debug("No email provided for subscription downgrade notification", {
+            subscriptionId: event.payload.subscriptionId,
+          })
+          return
+        }
+
+        if (await this.isIntegrationManaged(event.payload.userId)) {
+          this.logger.info("Skipping subscription downgraded email for integration-managed user", {
+            userId: event.payload.userId,
             subscriptionId: event.payload.subscriptionId,
           })
           return

--- a/api/infrastructure/external-api/user-api.interface.ts
+++ b/api/infrastructure/external-api/user-api.interface.ts
@@ -82,6 +82,13 @@ export interface User {
   role?: string
   team_id?: number
   whitelabel_id?: number
+  /**
+   * External integration that governs this user's premium status (e.g. KW
+   * Community / Chargify = 1). When set, premium is controlled by that
+   * integration — the billing system must NOT strip premium from these users.
+   * See updateUser() guard (#1473, #1494).
+   */
+  integration_id?: number | null
 }
 
 /**

--- a/api/infrastructure/external-api/user-api/mock-user-api.client.ts
+++ b/api/infrastructure/external-api/user-api/mock-user-api.client.ts
@@ -78,6 +78,14 @@ export class MockUserApiClient implements IUserApiClient {
       throw new Error('User not found')
     }
 
+    // Mirror the real client: never strip premium from integration-managed
+    // users (premium is governed by an external integration, e.g. KW
+    // Community/Chargify). #1473, #1494.
+    const wantsPremiumOff = userData.is_premium === 0 || userData.is_premium === false
+    if (wantsPremiumOff && user.integration_id != null) {
+      return user
+    }
+
     // Mirror the real client: accept 0|1 or boolean for is_premium/active.
     const normalized: Partial<User> = { ...userData } as Partial<User>
     if (typeof userData.is_premium === 'number') {
@@ -115,6 +123,10 @@ export class MockUserApiClient implements IUserApiClient {
 
   async deactivateUser(userId: number): Promise<void> {
     await this.updateUser(userId, { active: false })
+  }
+
+  async shellUser(userId: number): Promise<void> {
+    await this.updateUser(userId, { role: 'SHELL', is_premium: false })
   }
 
   async activateUser(userId: number): Promise<void> {
@@ -155,6 +167,7 @@ export class MockUserApiClient implements IUserApiClient {
       is_premium: user.is_premium ?? false,
       created_at: user.created_at || new Date().toISOString(),
       updated_at: user.updated_at || new Date().toISOString(),
+      integration_id: user.integration_id ?? null,
     }
 
     this.users.set(userId, fullUser)

--- a/api/infrastructure/external-api/user-api/user-api.client.test.ts
+++ b/api/infrastructure/external-api/user-api/user-api.client.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import axios from "axios"
+import { UserApiClient } from "./user-api.client"
+import type { IConfig } from "@api/config/config.interface"
+import type { ILogger } from "@api/infrastructure/logging/logger.interface"
+
+vi.mock("axios")
+
+const mockedAxios = axios as unknown as {
+  get: ReturnType<typeof vi.fn>
+  put: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+}
+
+function makeLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as ILogger
+}
+
+function makeConfig(): IConfig {
+  return { api: { url: "https://api.test", masterToken: "tok" } } as unknown as IConfig
+}
+
+function userResponse(overrides: Record<string, unknown>) {
+  return {
+    status: 200,
+    data: {
+      success: "success",
+      data: { user_id: 26126, email: "a@kw.com", is_premium: 1, active: 1, ...overrides },
+    },
+  }
+}
+
+describe("UserApiClient.updateUser — integration-managed premium guard", () => {
+  let client: UserApiClient
+  let logger: ILogger
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    logger = makeLogger()
+    client = new UserApiClient(makeConfig(), logger)
+  })
+
+  it("skips premium downgrade for an integration-managed user (no PUT)", async () => {
+    mockedAxios.get.mockResolvedValue(userResponse({ integration_id: 1, is_premium: 1 }))
+
+    const result = await client.updateUser(26126, { is_premium: 0 })
+
+    expect(mockedAxios.put).not.toHaveBeenCalled()
+    expect(result.is_premium).toBe(true)
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Skipping premium downgrade for integration-managed user",
+      expect.objectContaining({ userId: 26126, integrationId: 1 })
+    )
+  })
+
+  it("skips the role=SHELL downgrade too for an integration-managed user", async () => {
+    mockedAxios.get.mockResolvedValue(userResponse({ integration_id: 1, is_premium: 1 }))
+
+    await client.updateUser(26126, { role: "SHELL", is_premium: 0 })
+
+    expect(mockedAxios.put).not.toHaveBeenCalled()
+  })
+
+  it("downgrades a non-integration user normally (PUT sent)", async () => {
+    mockedAxios.get.mockResolvedValue(userResponse({ integration_id: null, is_premium: 1 }))
+    mockedAxios.put.mockResolvedValue(userResponse({ integration_id: null, is_premium: 0 }))
+
+    await client.updateUser(555, { is_premium: 0 })
+
+    expect(mockedAxios.put).toHaveBeenCalledTimes(1)
+    const [, body] = mockedAxios.put.mock.calls[0]
+    expect(body).toMatchObject({ is_premium: 0 })
+  })
+
+  it("deactivateUserPremium is a no-op for an integration-managed user", async () => {
+    mockedAxios.get.mockResolvedValue(userResponse({ integration_id: 1, is_premium: 1 }))
+
+    await client.deactivateUserPremium(26126)
+
+    expect(mockedAxios.put).not.toHaveBeenCalled()
+  })
+
+  it("does not gate non-downgrade updates (is_premium:1 still PUTs for integration user)", async () => {
+    mockedAxios.put.mockResolvedValue(userResponse({ integration_id: 1, is_premium: 1 }))
+
+    await client.updateUser(26126, { is_premium: 1 })
+
+    // is_premium:1 is not a downgrade, so no pre-fetch guard and the PUT goes through.
+    expect(mockedAxios.put).toHaveBeenCalledTimes(1)
+  })
+})

--- a/api/infrastructure/external-api/user-api/user-api.client.ts
+++ b/api/infrastructure/external-api/user-api/user-api.client.ts
@@ -157,6 +157,26 @@ export class UserApiClient implements IUserApiClient {
   async updateUser(userId: number, userData: UpdateUserRequest): Promise<User> {
     const startTime = Date.now()
 
+    // Guard: never strip premium from integration-managed users. Their premium
+    // is governed by an external integration (KW Community / Chargify), not by
+    // this Square billing system, so a lapse/cancel here must not downgrade
+    // them. A KW agent updating her card was wrongly moved to free (#1494; same
+    // root cause as #1473). Any update that turns is_premium off for a user
+    // with integration_id set is skipped entirely (this also covers the
+    // role=SHELL downgrade path) and logged for audit.
+    const wantsPremiumOff = userData.is_premium === 0 || userData.is_premium === false
+    if (wantsPremiumOff) {
+      const existing = await this.getUser(userId)
+      if (existing && existing.integration_id != null) {
+        this.logger.warn("Skipping premium downgrade for integration-managed user", {
+          userId,
+          integrationId: existing.integration_id,
+          requested: userData,
+        })
+        return existing
+      }
+    }
+
     try {
       this.logger.debug("Updating user via API", { userId })
 
@@ -377,6 +397,7 @@ export class UserApiClient implements IUserApiClient {
       updated_at: userData.updated || userData.updated_at || new Date().toISOString(),
       reset_token: userData.reset_token,
       whitelabel_id: userData.whitelabel_id ?? undefined,
+      integration_id: userData.integration_id ?? null,
     }
   }
 }


### PR DESCRIPTION
## Problem

KW Community / Chargify-managed agents (`Users.integration_id` set, KW = `integration_id 1`) were being moved to **Free** by this Square billing service whenever it processed a subscription cancel/lapse/suspension — even though their premium is governed by the **integration**, not by Square. A KW agent who merely **updated her card** was downgraded to free and emailed (Zoho Desk #1494; same root cause as #1473).

The billing identity is MASTER user `david+co@dbmgrow.com`, which calls `PUT /users/:id {is_premium:0}` via `UserApiClient`. Nothing checked `integration_id`.

## Fix (two parts — end-to-end testing showed the premium guard alone wasn't enough)

1. **Premium guard** — `UserApiClient.updateUser` short-circuits any `is_premium → 0/false` update for a user with `integration_id` set (covers `deactivateUserPremium`, `shellUser`, and `CashOffersAccountHandler`'s direct calls).
2. **Email guard** — `EmailNotificationHandler` suppresses the Square lapse/suspension/cancellation/**downgrade-to-free** emails for integration-managed users. Without this, the agent kept premium but still received a "Your Subscription Has Been Downgraded to Free" email — the exact complaint.
3. Added `integration_id` to the `User` interface + `parseUser()` (the CashOffers `GET /users/:id` returns it via the `Users_Dash` view). Mirrored the guard in `MockUserApiClient` and added its missing `shellUser`.

## Verification

- **Unit:** `user-api.client.test.ts` — 5/5 (guard incl. SHELL path, control downgrade still works, `deactivateUserPremium` no-op for integration users).
- **Live end-to-end (staging `yarn dev:tools` + Mailpit):** two throwaway `downgrade-on-renewal` users, identical except `integration_id`. Treatment (`integration_id=1`) → `is_premium` stayed **true** and **no email**. Control → downgraded + "Downgraded to Free" email. Both ran the same cancel→`DOWNGRADE_TO_FREE` path.
- `typecheck:api`: no errors in changed files (also cleared 3 pre-existing `MockUserApiClient` errors by adding `shellUser`).

## Notes / follow-ups (not blockers)

- `email-notification.handler.test.ts` is included but **can't run** under the current vitest workspace — runtime `@api/*` imports don't resolve there (same pre-existing gap that red-lists this repo's integration tests). Behavior is instead proven by the live A/B.
- Hardening opportunities (optional): the guard sits at the generic `updateUser` chokepoint, so it also skips the rare cross-product case (an integration user going through a managed `is_premium:0` product); and `getUser` failure currently fails the downgrade closed. Moving the guard to the suspension handlers + fail-open would tighten both. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)