### PR TITLE
CO-I127 commission accrual push (Phase 3, billing side)

### DIFF
--- a/api/application/event-handlers/commission-accrual.handler.test.ts
+++ b/api/application/event-handlers/commission-accrual.handler.test.ts
@@ -52,9 +52,12 @@ describe("CommissionAccrualHandler", () => {
     expect(client.reverse).not.toHaveBeenCalled()
   })
 
-  it("PaymentRefunded → reverse using the ORIGINAL transaction_id", async () => {
-    await handler.handle(makeEvent("PaymentRefunded", { transactionId: 9001, originalTransactionId: 3599 }))
-    expect(client.reverse).toHaveBeenCalledWith({ transaction_id: 3599 })
+  it("PaymentRefunded → reverse using the ORIGINAL transaction_id + refunded amount", async () => {
+    await handler.handle(
+      makeEvent("PaymentRefunded", { transactionId: 9001, originalTransactionId: 3599, amount: 4900 })
+    )
+    // api-v2 /reverse needs the refunded cents to reverse the commission proportionally.
+    expect(client.reverse).toHaveBeenCalledWith({ transaction_id: 3599, chargeback_amount: 4900 })
     expect(client.accrue).not.toHaveBeenCalled()
   })
 

--- a/api/application/event-handlers/commission-accrual.handler.test.ts
+++ b/api/application/event-handlers/commission-accrual.handler.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { CommissionAccrualHandler } from "./commission-accrual.handler"
+import type { ICommissionApiClient } from "@api/infrastructure/external-api/commission-api.interface"
+import type { IDomainEvent } from "@api/infrastructure/events/event-bus.interface"
+
+// Minimal logger stub — BaseEventHandler calls logger.child() in its constructor.
+function makeLogger() {
+  const calls: { level: string; msg: string; meta?: unknown }[] = []
+  const log = {
+    calls,
+    child: () => log,
+    info: (msg: string, meta?: unknown) => calls.push({ level: "info", msg, meta }),
+    warn: (msg: string, meta?: unknown) => calls.push({ level: "warn", msg, meta }),
+    error: (msg: string, _e?: unknown, meta?: unknown) => calls.push({ level: "error", msg, meta }),
+    debug: (msg: string, meta?: unknown) => calls.push({ level: "debug", msg, meta }),
+  }
+  return log as any
+}
+
+function makeEvent(eventType: string, payload: Record<string, unknown>): IDomainEvent {
+  return {
+    eventId: "evt-1",
+    eventType,
+    occurredAt: new Date(),
+    aggregateId: 1,
+    aggregateType: "Test",
+    payload,
+  }
+}
+
+describe("CommissionAccrualHandler", () => {
+  let client: ICommissionApiClient & { accrue: ReturnType<typeof vi.fn>; reverse: ReturnType<typeof vi.fn> }
+  let logger: ReturnType<typeof makeLogger>
+  let handler: CommissionAccrualHandler
+
+  beforeEach(() => {
+    client = { accrue: vi.fn(async () => {}), reverse: vi.fn(async () => {}) }
+    logger = makeLogger()
+    handler = new CommissionAccrualHandler(client, logger)
+  })
+
+  it("subscribes to the three money-moving events", () => {
+    expect(handler.getEventTypes()).toEqual(["PaymentProcessed", "SubscriptionRenewed", "PaymentRefunded"])
+  })
+
+  it("PaymentProcessed → accrue with the payment transaction_id", async () => {
+    await handler.handle(makeEvent("PaymentProcessed", { transactionId: 3599 }))
+    expect(client.accrue).toHaveBeenCalledWith({ transaction_id: 3599 })
+    expect(client.reverse).not.toHaveBeenCalled()
+  })
+
+  it("SubscriptionRenewed → accrue with the renewal transaction_id", async () => {
+    await handler.handle(makeEvent("SubscriptionRenewed", { transactionId: 3600 }))
+    expect(client.accrue).toHaveBeenCalledWith({ transaction_id: 3600 })
+  })
+
+  it("PaymentRefunded → reverse using the ORIGINAL transaction_id", async () => {
+    await handler.handle(makeEvent("PaymentRefunded", { transactionId: 9001, originalTransactionId: 3599 }))
+    expect(client.reverse).toHaveBeenCalledWith({ transaction_id: 3599 })
+    expect(client.accrue).not.toHaveBeenCalled()
+  })
+
+  it("missing transaction_id → skipped with a warning, no client call", async () => {
+    await handler.handle(makeEvent("PaymentProcessed", {}))
+    expect(client.accrue).not.toHaveBeenCalled()
+    expect(logger.calls.some((c: any) => c.level === "warn" && c.msg.includes("skipped"))).toBe(true)
+  })
+
+  it("client failure is swallowed (sweep reconciles) — handler does NOT throw", async () => {
+    client.accrue = vi.fn(async () => {
+      throw new Error("api-v2 unreachable (404)")
+    })
+    handler = new CommissionAccrualHandler(client, logger)
+    await expect(handler.handle(makeEvent("PaymentProcessed", { transactionId: 3599 }))).resolves.toBeUndefined()
+    expect(logger.calls.some((c: any) => c.level === "warn" || c.level === "error")).toBe(true)
+  })
+})

--- a/api/application/event-handlers/commission-accrual.handler.test.ts
+++ b/api/application/event-handlers/commission-accrual.handler.test.ts
@@ -39,19 +39,17 @@ describe("CommissionAccrualHandler", () => {
     handler = new CommissionAccrualHandler(client, logger)
   })
 
-  it("subscribes to the three money-moving events", () => {
-    expect(handler.getEventTypes()).toEqual(["PaymentProcessed", "SubscriptionRenewed", "PaymentRefunded"])
+  it("subscribes to PaymentProcessed + PaymentRefunded only (NOT SubscriptionRenewed)", () => {
+    // SubscriptionRenewed is excluded so a renewal (which emits both events,
+    // writing two transaction rows) accrues exactly once. See getEventTypes.
+    expect(handler.getEventTypes()).toEqual(["PaymentProcessed", "PaymentRefunded"])
+    expect(handler.getEventTypes()).not.toContain("SubscriptionRenewed")
   })
 
   it("PaymentProcessed → accrue with the payment transaction_id", async () => {
     await handler.handle(makeEvent("PaymentProcessed", { transactionId: 3599 }))
     expect(client.accrue).toHaveBeenCalledWith({ transaction_id: 3599 })
     expect(client.reverse).not.toHaveBeenCalled()
-  })
-
-  it("SubscriptionRenewed → accrue with the renewal transaction_id", async () => {
-    await handler.handle(makeEvent("SubscriptionRenewed", { transactionId: 3600 }))
-    expect(client.accrue).toHaveBeenCalledWith({ transaction_id: 3600 })
   })
 
   it("PaymentRefunded → reverse using the ORIGINAL transaction_id", async () => {

--- a/api/application/event-handlers/commission-accrual.handler.ts
+++ b/api/application/event-handlers/commission-accrual.handler.ts
@@ -1,0 +1,64 @@
+import { BaseEventHandler } from "@api/infrastructure/events/base-event-handler"
+import type { IDomainEvent } from "@api/infrastructure/events/event-bus.interface"
+import type { ILogger } from "@api/infrastructure/logging/logger.interface"
+import type { ICommissionApiClient } from "@api/infrastructure/external-api/commission-api.interface"
+
+/**
+ * Pushes commission accrual/reversal to api-v2 the moment money moves.
+ *
+ * Subscribes to the three events that represent a transaction settling or
+ * reversing, and forwards `{ transaction_id }` to api-v2's internal commission
+ * endpoints. Billing owns only this trigger; api-v2 does all the computation.
+ *
+ * Non-fatal by design: this is a LATENCY optimization, not a correctness
+ * guarantee. The api-v2 reconciliation sweep over the shared `Transactions`
+ * table accrues anything this push misses, so a failed/dropped push must never
+ * fail the wider event processing — hence `safeExecute` (logs, never re-throws).
+ *
+ * See docs/plans/commission-accrual-push-plan.md.
+ */
+export class CommissionAccrualHandler extends BaseEventHandler {
+  constructor(
+    private commissionApiClient: ICommissionApiClient,
+    logger: ILogger
+  ) {
+    super(logger)
+  }
+
+  getEventTypes(): string[] {
+    return ["PaymentProcessed", "SubscriptionRenewed", "PaymentRefunded"]
+  }
+
+  async handle(event: IDomainEvent): Promise<void> {
+    const isRefund = event.eventType === "PaymentRefunded"
+
+    // Refunds carry both the refund txn and the ORIGINAL payment txn — reverse
+    // the original. Payments/renewals carry the settled transaction id directly.
+    const transactionId: number | undefined = isRefund
+      ? event.payload?.originalTransactionId
+      : event.payload?.transactionId
+
+    if (transactionId == null) {
+      this.logger.warn("commission push skipped: no transaction_id on event", {
+        eventType: event.eventType,
+        eventId: event.eventId,
+      })
+      return
+    }
+
+    const action = isRefund ? "reverse" : "accrue"
+
+    await this.safeExecute(
+      async () => {
+        if (isRefund) {
+          await this.commissionApiClient.reverse({ transaction_id: transactionId })
+        } else {
+          await this.commissionApiClient.accrue({ transaction_id: transactionId })
+        }
+        this.logger.info("commission push ok", { transactionId, action, eventType: event.eventType })
+      },
+      event,
+      "commission push failed (api-v2 sweep will reconcile)"
+    )
+  }
+}

--- a/api/application/event-handlers/commission-accrual.handler.ts
+++ b/api/application/event-handlers/commission-accrual.handler.ts
@@ -6,9 +6,9 @@ import type { ICommissionApiClient } from "@api/infrastructure/external-api/comm
 /**
  * Pushes commission accrual/reversal to api-v2 the moment money moves.
  *
- * Forwards `{ transaction_id }` to api-v2's internal commission endpoints on a
- * settled payment or a refund. Billing owns only this trigger; api-v2 does all
- * the computation.
+ * Forwards the settled/refunded `transaction_id` (plus the refunded amount on a
+ * reversal) to api-v2's internal commission endpoints on a settled payment or a
+ * refund. Billing owns only this trigger; api-v2 does all the computation.
  *
  * Non-fatal by design: this is a LATENCY optimization, not a correctness
  * guarantee. The api-v2 reconciliation sweep over the shared `Transactions`
@@ -58,7 +58,13 @@ export class CommissionAccrualHandler extends BaseEventHandler {
     await this.safeExecute(
       async () => {
         if (isRefund) {
-          await this.commissionApiClient.reverse({ transaction_id: transactionId })
+          // api-v2 /reverse requires the refunded amount (cents) so it can
+          // recompute the reversed commission — a partial refund reverses
+          // proportionally. PaymentRefundedPayload.amount is the refunded cents.
+          await this.commissionApiClient.reverse({
+            transaction_id: transactionId,
+            chargeback_amount: event.payload?.amount,
+          })
         } else {
           await this.commissionApiClient.accrue({ transaction_id: transactionId })
         }

--- a/api/application/event-handlers/commission-accrual.handler.ts
+++ b/api/application/event-handlers/commission-accrual.handler.ts
@@ -6,9 +6,9 @@ import type { ICommissionApiClient } from "@api/infrastructure/external-api/comm
 /**
  * Pushes commission accrual/reversal to api-v2 the moment money moves.
  *
- * Subscribes to the three events that represent a transaction settling or
- * reversing, and forwards `{ transaction_id }` to api-v2's internal commission
- * endpoints. Billing owns only this trigger; api-v2 does all the computation.
+ * Forwards `{ transaction_id }` to api-v2's internal commission endpoints on a
+ * settled payment or a refund. Billing owns only this trigger; api-v2 does all
+ * the computation.
  *
  * Non-fatal by design: this is a LATENCY optimization, not a correctness
  * guarantee. The api-v2 reconciliation sweep over the shared `Transactions`
@@ -26,7 +26,14 @@ export class CommissionAccrualHandler extends BaseEventHandler {
   }
 
   getEventTypes(): string[] {
-    return ["PaymentProcessed", "SubscriptionRenewed", "PaymentRefunded"]
+    // Deliberately NOT "SubscriptionRenewed": a renewal emits BOTH
+    // PaymentProcessed and SubscriptionRenewed, which write two Transactions rows
+    // (payment + subscription) sharing one Square id but with different internal
+    // ids. Subscribing to both would accrue the same sale twice (the api-v2
+    // uq_ledger_txn_role key can't dedupe across two transaction_ids).
+    // PaymentProcessed fires for one-time charges AND renewals — and its row
+    // carries product_id — so it covers everything, exactly once.
+    return ["PaymentProcessed", "PaymentRefunded"]
   }
 
   async handle(event: IDomainEvent): Promise<void> {

--- a/api/config/config.interface.ts
+++ b/api/config/config.interface.ts
@@ -48,6 +48,7 @@ export interface IConfig {
     urlV2: string // API_URL_V2 - main API v2 base URL (e.g. https://app.cashoffers.pro/api/v2)
     masterToken: string
     key: string // API_KEY - token for calling main auth API
+    internalToken?: string // API_TOKEN_INTERNAL - service token for api-v2 /internal/* routes (commission accrual push)
     route?: string // API_ROUTE - internal/billing API base URL (optional)
   }
 

--- a/api/config/config.service.ts
+++ b/api/config/config.service.ts
@@ -67,6 +67,7 @@ const buildConfig = (): IConfig => {
       urlV2: process.env.API_URL_V2!,
       masterToken: process.env.API_MASTER_TOKEN!,
       key: process.env.API_KEY!,
+      internalToken: process.env.API_TOKEN_INTERNAL,
       route: process.env.API_ROUTE,
     },
 

--- a/api/infrastructure/external-api/commission-api.client.ts
+++ b/api/infrastructure/external-api/commission-api.client.ts
@@ -1,0 +1,74 @@
+import axios from "axios"
+import type { IConfig } from "@api/config/config.interface"
+import type { ILogger } from "@api/infrastructure/logging/logger.interface"
+import type { ICommissionApiClient, CommissionAccrualInput } from "./commission-api.interface"
+import { DEFAULT_HTTP_TIMEOUT_MS, withHttpRetry } from "./http-retry"
+
+/**
+ * Commission API Client Implementation
+ *
+ * POSTs to api-v2's internal commission endpoints. Mirrors `UserApiClient`'s
+ * outbound pattern (axios + master token + transient-failure retry), but targets
+ * the v2 base (`config.api.urlV2`) and the `/internal/commissions/*` routes.
+ *
+ * Correctness note: a failed push is NOT fatal — the api-v2 reconciliation sweep
+ * over the shared `Transactions` table reconciles anything this misses. The
+ * accrue/reverse endpoints are idempotent (unique key on transaction_id + role),
+ * so the retry below is safe and a double-delivery is harmless.
+ */
+export class CommissionApiClient implements ICommissionApiClient {
+  constructor(
+    private config: IConfig,
+    private logger: ILogger
+  ) {
+    this.logger.debug("Commission API client initialized", { apiUrl: config.api.urlV2 })
+  }
+
+  private async post(path: string, input: CommissionAccrualInput): Promise<void> {
+    const url = `${this.config.api.urlV2}${path}`
+    const startTime = Date.now()
+
+    await withHttpRetry(
+      () =>
+        axios.post(url, input, {
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-token": this.config.api.masterToken,
+          },
+          timeout: DEFAULT_HTTP_TIMEOUT_MS,
+        }),
+      {
+        onRetry: ({ attempt, delayMs, error }) => {
+          this.logger.warn("Retrying commission API request after transient failure", {
+            path,
+            transactionId: input.transaction_id,
+            attempt,
+            delayMs,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        },
+      }
+    )
+
+    this.logger.debug("Commission API request ok", {
+      path,
+      transactionId: input.transaction_id,
+      duration: Date.now() - startTime,
+    })
+  }
+
+  async accrue(input: CommissionAccrualInput): Promise<void> {
+    await this.post("/internal/commissions/accrue", input)
+  }
+
+  async reverse(input: CommissionAccrualInput): Promise<void> {
+    await this.post("/internal/commissions/reverse", input)
+  }
+}
+
+/**
+ * Create a commission API client
+ */
+export const createCommissionApiClient = (config: IConfig, logger: ILogger): ICommissionApiClient => {
+  return new CommissionApiClient(config, logger)
+}

--- a/api/infrastructure/external-api/commission-api.client.ts
+++ b/api/infrastructure/external-api/commission-api.client.ts
@@ -33,7 +33,10 @@ export class CommissionApiClient implements ICommissionApiClient {
         axios.post(url, input, {
           headers: {
             "Content-Type": "application/json",
-            "x-api-token": this.config.api.masterToken,
+            // api-v2 /internal/commissions/* is guarded by the internal service
+            // token (x-api-token-internal === env.API_TOKEN_INTERNAL), NOT the
+            // master token. Must match api-v2 Phase 3's commissions.internal.routes.
+            "x-api-token-internal": this.config.api.internalToken,
           },
           timeout: DEFAULT_HTTP_TIMEOUT_MS,
         }),

--- a/api/infrastructure/external-api/commission-api.interface.ts
+++ b/api/infrastructure/external-api/commission-api.interface.ts
@@ -1,0 +1,21 @@
+/**
+ * Commission API Client Interface
+ *
+ * Thin outbound client that notifies the CashOffers api-v2 commission system
+ * when a transaction should accrue (or reverse) a commission. Billing owns ONLY
+ * the trigger — all commission computation (hierarchy, schedules, ledger) lives
+ * in api-v2. See docs/plans/commission-accrual-push-plan.md.
+ */
+
+export interface CommissionAccrualInput {
+  /** Internal CashOffers transaction id (Transactions.transaction_id). */
+  transaction_id: number
+}
+
+export interface ICommissionApiClient {
+  /** Accrue commission for a settled transaction (payment / subscription renewal). */
+  accrue(input: CommissionAccrualInput): Promise<void>
+
+  /** Reverse commission for a refunded transaction. */
+  reverse(input: CommissionAccrualInput): Promise<void>
+}

--- a/api/infrastructure/external-api/commission-api.interface.ts
+++ b/api/infrastructure/external-api/commission-api.interface.ts
@@ -10,6 +10,12 @@
 export interface CommissionAccrualInput {
   /** Internal CashOffers transaction id (Transactions.transaction_id). */
   transaction_id: number
+  /**
+   * Refunded amount in cents. Required by api-v2 `/internal/commissions/reverse`
+   * (it recomputes net revenue as gross − platform_fee − chargeback_amount, so a
+   * partial refund reverses the commission proportionally). Omitted for accrue.
+   */
+  chargeback_amount?: number
 }
 
 export interface ICommissionApiClient {

--- a/api/lib/services.ts
+++ b/api/lib/services.ts
@@ -122,9 +122,10 @@ eventBus.subscribe("SubscriptionDeactivated", cashOffersAccountHandler)
 eventBus.subscribe("SubscriptionCancelled", cashOffersAccountHandler)
 
 // Commission accrual push to api-v2 (near-real-time; the api-v2 sweep is the
-// correctness backstop). Refunds reverse; payments/renewals accrue.
+// correctness backstop). PaymentProcessed covers one-time charges AND renewals
+// exactly once; SubscriptionRenewed is intentionally NOT subscribed (it would
+// double-accrue a renewal — see CommissionAccrualHandler.getEventTypes).
 eventBus.subscribe("PaymentProcessed", commissionAccrualHandler)
-eventBus.subscribe("SubscriptionRenewed", commissionAccrualHandler)
 eventBus.subscribe("PaymentRefunded", commissionAccrualHandler)
 
 // HomeUptick account management

--- a/api/lib/services.ts
+++ b/api/lib/services.ts
@@ -18,6 +18,7 @@ import { createSquareErrorTranslator } from "@api/infrastructure/payment/error/s
 import { createSendGridEmailService } from "@api/infrastructure/email/sendgrid/sendgrid.service"
 import { createSmtpEmailService } from "@api/infrastructure/email/smtp/smtp.service"
 import { createUserApiClient } from "@api/infrastructure/external-api/user-api/user-api.client"
+import { createCommissionApiClient } from "@api/infrastructure/external-api/commission-api.client"
 import { InMemoryEventBus } from "@api/infrastructure/events/in-memory-event-bus"
 import { EmailNotificationHandler } from "@api/application/event-handlers/email-notification.handler"
 import { TransactionLoggingHandler } from "@api/application/event-handlers/transaction-logging.handler"
@@ -25,6 +26,7 @@ import { LogFlushHandler } from "@api/application/event-handlers/log-flush.handl
 import { CashOffersAccountHandler } from "@api/application/service-handlers/cashoffers/cashoffers-account.handler"
 import { HomeUptickAccountHandler } from "@api/application/service-handlers/homeuptick/homeuptick-account.handler"
 import { AdminAlertHandler } from "@api/application/event-handlers/admin-alert.handler"
+import { CommissionAccrualHandler } from "@api/application/event-handlers/commission-accrual.handler"
 import { createHomeUptickApiClient } from "@api/infrastructure/external-api/homeuptick-api/homeuptick-api.client"
 import { createHealthMetricsService } from "@api/domain/services/health-metrics.service"
 import { createHealthReportService } from "@api/domain/services/health-report.service"
@@ -69,6 +71,7 @@ export const emailService =
 
 export const userApiClient = createUserApiClient(config, logger)
 export const homeUptickApiClient = createHomeUptickApiClient(config, logger, db)
+export const commissionApiClient = createCommissionApiClient(config, logger)
 
 export const healthMetricsService = createHealthMetricsService(
   transactionRepository,
@@ -90,6 +93,7 @@ const rawCashOffersAccountHandler = new CashOffersAccountHandler(userApiClient, 
 const rawHomeUptickAccountHandler = new HomeUptickAccountHandler(homeUptickApiClient, logger)
 const cashOffersAccountHandler = new AdminAlertHandler(rawCashOffersAccountHandler, criticalAlertService, 'CashOffersAccountHandler', logger)
 const homeUptickAccountHandler = new AdminAlertHandler(rawHomeUptickAccountHandler, criticalAlertService, 'HomeUptickAccountHandler', logger)
+const commissionAccrualHandler = new CommissionAccrualHandler(commissionApiClient, logger)
 
 eventBus.subscribe("SubscriptionCreated", emailNotificationHandler)
 eventBus.subscribe("SubscriptionRenewed", emailNotificationHandler)
@@ -116,6 +120,12 @@ eventBus.subscribe("SubscriptionUpgraded", cashOffersAccountHandler)
 eventBus.subscribe("SubscriptionPaused", cashOffersAccountHandler)
 eventBus.subscribe("SubscriptionDeactivated", cashOffersAccountHandler)
 eventBus.subscribe("SubscriptionCancelled", cashOffersAccountHandler)
+
+// Commission accrual push to api-v2 (near-real-time; the api-v2 sweep is the
+// correctness backstop). Refunds reverse; payments/renewals accrue.
+eventBus.subscribe("PaymentProcessed", commissionAccrualHandler)
+eventBus.subscribe("SubscriptionRenewed", commissionAccrualHandler)
+eventBus.subscribe("PaymentRefunded", commissionAccrualHandler)
 
 // HomeUptick account management
 eventBus.subscribe("SubscriptionCreated", homeUptickAccountHandler)

--- a/docs/development/quality/todos.md
+++ b/docs/development/quality/todos.md
@@ -49,3 +49,9 @@ Active implementation gaps tracked here. Link to discrepancy if one exists.
 ### TODO-008: Add CLI Scenarios for Pause/Resume and Cancel on Renewal
 - **File**: `scripts/dev.ts`
 - **What**: Dev CLI has no scenarios for these common operations
+
+### TODO-009: Square Dispute/Chargeback Webhook for Commission Reversal
+- **What**: The commission accrual push (`CommissionAccrualHandler`) reverses commissions on **refunds** (`PaymentRefundedEvent`). It does **not** handle Square **disputes/chargebacks** (bank-forced reversals), which neither service handles today.
+- **For now**: a chargeback is reconciled when finance records the matching refund. The api-v2 reconciliation sweep over the shared `Transactions` table remains the correctness backstop.
+- **Later**: add a Square `dispute.created` webhook handler → `POST /internal/commissions/reverse`.
+- **See**: `docs/plans/commission-accrual-push-plan.md` (§6 Out of scope)


### PR DESCRIPTION
Companion to api-v2 **PR #646 (Phase 3)**. Adds a thin event handler that pushes `{ transaction_id }` to api-v2's `/internal/commissions/accrue|reverse` so commissions accrue in near-real-time. Billing owns only the trigger; api-v2 does all computation. Non-fatal by design — the api-v2 reconciliation sweep is the correctness backstop.

### Files
- `commission-accrual.handler.ts` — subscribes to payment/refund events, forwards to api-v2
- `commission-api.client.ts` (+ interface) — outbound client
- `services.ts` — handler registration
- `commission-accrual.handler.test.ts` — unit tests

### Follow-up fix commits in this PR
- **Auth:** authenticate the push with the internal service token (`x-api-token-internal` / `API_TOKEN_INTERNAL`) to match Phase 3's route. ⚠️ Requires `API_TOKEN_INTERNAL` in billing env (same value as api-v2).
- **Renewal double-fire:** a renewal emits both `PaymentProcessed` and `SubscriptionRenewed` (two transaction rows, same Square id) — accrue once to avoid double-counting.

> Note for api-v2 PR #646: the sweep must also dedupe the two-row renewal, or it double-counts independently of the push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)