### PR TITLE
fix(CO-I127): fix commission accrual push (master token + payment row)

### DIFF
--- a/api/infrastructure/external-api/commission-api.client.ts
+++ b/api/infrastructure/external-api/commission-api.client.ts
@@ -33,10 +33,11 @@ export class CommissionApiClient implements ICommissionApiClient {
         axios.post(url, input, {
           headers: {
             "Content-Type": "application/json",
-            // api-v2 /internal/commissions/* is guarded by the internal service
-            // token (x-api-token-internal === env.API_TOKEN_INTERNAL), NOT the
-            // master token. Must match api-v2 Phase 3's commissions.internal.routes.
-            "x-api-token-internal": this.config.api.internalToken,
+            // api-v2 /internal/commissions/* resolves x-api-token → a MASTER
+            // session and requires commissions_manage. We reuse the master token
+            // (same credential as UserApiClient) so no dedicated internal secret
+            // needs provisioning across environments.
+            "x-api-token": this.config.api.masterToken,
           },
           timeout: DEFAULT_HTTP_TIMEOUT_MS,
         }),

--- a/api/use-cases/subscription/renew-subscription.use-case.ts
+++ b/api/use-cases/subscription/renew-subscription.use-case.ts
@@ -337,9 +337,10 @@ export class RenewSubscriptionUseCase implements IRenewSubscriptionUseCase {
       }
 
       // Log payment transaction (separate from the subscription renewal transaction)
+      let paymentTransactionId: number | null = null
       if (paymentId && totalAmount > 0) {
         const now = new Date()
-        await this.deps.transactionRepository.create({
+        const paymentTransaction = await this.deps.transactionRepository.create({
           user_id: subscription.user_id!,
           amount: totalAmount,
           type: "payment",
@@ -352,6 +353,7 @@ export class RenewSubscriptionUseCase implements IRenewSubscriptionUseCase {
           createdAt: now,
           updatedAt: now,
         })
+        paymentTransactionId = paymentTransaction.transaction_id
       }
 
       // Update status to CREATING_SUBSCRIPTION (updating renewal)
@@ -426,7 +428,11 @@ export class RenewSubscriptionUseCase implements IRenewSubscriptionUseCase {
       if (paymentId && totalAmount > 0) {
         await this.deps.eventBus.publish(
           PaymentProcessedEvent.create({
-            transactionId: transactionId!,
+            // Reference the PAYMENT transaction (it carries product_id), not the
+            // subscription row. api-v2's commission accrual keys on the row with
+            // product_id; pointing at the subscription row (NULL product) makes
+            // its renewal de-dupe skip the push and the sale never accrues.
+            transactionId: paymentTransactionId ?? transactionId!,
             externalTransactionId: paymentId,
             userId: subscription.user_id!,
             email: validatedInput.email,


### PR DESCRIPTION
## Problem

The billing → api-v2 commission accrual push (added in #25) never accrued anything:

1. **Auth** — the push authenticated with `x-api-token-internal: API_TOKEN_INTERNAL`, but `API_TOKEN_INTERNAL` is **unset in every billing environment**, so api-v2 returned **401** and the push was silently swallowed (non-fatal by design).
2. **Renewals** — even with auth fixed, a renewal pushed the **subscription** transaction id (`product_id` NULL). api-v2's renewal de-dupe keys on the **payment** row (the one carrying `product_id`), so it skipped the push and the sale never accrued.

## Fix

- `commission-api.client.ts` — send the **master token** (`x-api-token`), the same credential `UserApiClient` already uses for every other api-v2 call. No dedicated internal secret needs provisioning across environments.
- `renew-subscription.use-case.ts` — `PaymentProcessedEvent` now references the **payment** transaction (carries `product_id`), not the subscription row. New subscriptions already reference the payment row; this aligns renewals with that.

## Pairs with api-v2

Requires the matching api-v2 change (commission internal routes now resolve `x-api-token` → a MASTER session and require `commissions_manage`). **Deploy both together.**

## Testing

Verified locally end-to-end against the staging DB:
- Renewal → accrues PoS / sponsor / affiliate up the white-label chain (20/10/20) ✅
- Refund → reverses all three rows to $0 ✅
- Both pushes authenticate (`commission push ok`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)