### PR TITLE
#1053 Require full name (first + last) on new-user purchase signup

### DIFF
--- a/api/tests/unit/newUserPurchaseNameValidation.test.ts
+++ b/api/tests/unit/newUserPurchaseNameValidation.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest"
+import { FullNameSchema, NewUserPurchaseInputSchema } from "@api/use-cases/types/validation.schemas"
+
+/**
+ * Regression coverage for Zoho Desk #1053 — agents were able to sign up through
+ * the public new-user purchase flow without providing a last name. The name
+ * field must now contain at least a first and last name.
+ */
+describe("FullNameSchema", () => {
+  it("accepts a first and last name", () => {
+    expect(FullNameSchema.parse("Jane Doe")).toBe("Jane Doe")
+  })
+
+  it("trims surrounding and collapses-tolerates inner whitespace", () => {
+    expect(FullNameSchema.parse("  Jane   Doe  ")).toBe("Jane   Doe")
+  })
+
+  it("rejects a single name with no last name", () => {
+    expect(FullNameSchema.safeParse("Annette").success).toBe(false)
+  })
+
+  it("rejects an empty or whitespace-only name", () => {
+    expect(FullNameSchema.safeParse("").success).toBe(false)
+    expect(FullNameSchema.safeParse("   ").success).toBe(false)
+  })
+
+  it("rejects a missing (null/undefined) name", () => {
+    expect(FullNameSchema.safeParse(null).success).toBe(false)
+    expect(FullNameSchema.safeParse(undefined).success).toBe(false)
+  })
+})
+
+describe("NewUserPurchaseInputSchema name validation", () => {
+  const base = {
+    productId: 1,
+    email: "agent@example.com",
+    phone: "+15555550123",
+  }
+
+  it("passes when a full name is provided", () => {
+    const result = NewUserPurchaseInputSchema.safeParse({ ...base, name: "Jane Doe" })
+    expect(result.success).toBe(true)
+  })
+
+  it("fails when the name has no last name", () => {
+    const result = NewUserPurchaseInputSchema.safeParse({ ...base, name: "Jane" })
+    expect(result.success).toBe(false)
+  })
+
+  it("fails when the name is omitted", () => {
+    const result = NewUserPurchaseInputSchema.safeParse({ ...base })
+    expect(result.success).toBe(false)
+  })
+})

--- a/api/use-cases/types/validation.schemas.ts
+++ b/api/use-cases/types/validation.schemas.ts
@@ -193,6 +193,20 @@ export const DeactivateSubscriptionInputSchema = z.object({
 export type DeactivateSubscriptionInputValidated = z.infer<typeof DeactivateSubscriptionInputSchema>
 
 /**
+ * Full name validator — requires both a first and last name.
+ * New agent signups (Zoho Desk #1053) were able to register through the public
+ * purchase flow with only a single name, so we require the name to contain at
+ * least two whitespace-separated parts (i.e. a space between first and last).
+ */
+export const FullNameSchema = z
+  .string({ error: "Full name is required" })
+  .trim()
+  .min(1, "Full name is required")
+  .refine((val) => val.split(/\s+/).filter(Boolean).length >= 2, {
+    message: "Please enter your first and last name",
+  })
+
+/**
  * New user purchase validation schema.
  * All card and identification fields are required.
  */
@@ -207,7 +221,7 @@ export const NewUserPurchaseInputSchema = z.object({
   expMonth: z.number().int().min(1).max(12).optional().nullable(),
   expYear: z.number().int().optional().nullable(),
   cardholderName: z.string().min(1, "Cardholder name is required").optional().nullable(),
-  name: z.string().optional().nullable(),
+  name: FullNameSchema,
   nameBroker: z.string().optional().nullable(),
   nameTeam: z.string().optional().nullable(),
   whitelabel: z.string().optional().nullable(),


### PR DESCRIPTION
**Zoho Desk ticket:** [#1053](https://desk.zoho.com/support/dbmgrow/ShowHomePage.do#Cases/dv/1003209000006514005)

## Summary
- New agents signing up through the public new-user purchase flow (KW Offerings, YHS, Instant Offers white-label sites) could register **without a last name**.
- `name` in `NewUserPurchaseInputSchema` was `z.string().optional().nullable()` with no full-name check, and `purchase-new-user.use-case.ts` falls back to `cardholderName || email` when it is missing — so a single-word name (or none) was accepted.
- Added a `FullNameSchema` (in `api/use-cases/types/validation.schemas.ts`) that trims the value and requires **at least two whitespace-separated parts** (a first and last name), and applied it to the new-user purchase `name` field. This rejects single-word signups server-side with a `PURCHASE_VALIDATION_ERROR` (HTTP 400), matching the approach David proposed in the ticket ("check to make sure their name has a space in it").
- Added unit coverage (`api/tests/unit/newUserPurchaseNameValidation.test.ts`).

## Root cause
- The public `POST /purchase/new` endpoint did not enforce a full name; the only server-side gatekeeper for white-label agent signups treated `name` as optional.

## Verification
- Typecheck: my change introduces **no new errors** (verified via baseline diff against `main`). Pre-existing, unrelated errors remain in the repo: the fumadocs `.source` codegen errors (`app/docs/**`, `lib/source.ts`) and `api/tests/integration/renewal-homeuptick-tiers.test.ts:397` — all present before this change.
- Unit tests: new suite passes (8/8); `api/tests/unit` otherwise unchanged. The two `getHomeUptickSubscription*` unit files fail only because the sandbox lacks DB/Square env vars (`DB_PASS`, `NEXT_PUBLIC_SQUARE_*`, `API_URL_V2`) — pre-existing, environment-only.

## Notes for the reviewer
- This enforces a full name for **all** new-user purchases, including investor (`isInvestor`) signups, not only the KW/YHS/Instant-Offers agent paths called out in the ticket. If investor signups must still allow a single name, the rule should be gated on the product/path — please confirm before merge.
- The route-level OpenAPI schema (`api/routes/purchase/schemas.ts`) still documents `name` as optional; the enforcement lives in the use-case validation layer (the actual gate). Tightening the OpenAPI contract to match could be a small follow-up.

_Auto-opened as a DRAFT by /fix-urgent-ticket. Requires human testing and review before merge; never auto-merged._

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuqWCBYyyf7femZD7tdwDm)_