### PR TITLE
#1514 Fix "subscription_id is required" error when changing plan

### DIFF
--- a/components/forms/manage/steps/UpdatePlanStep.tsx
+++ b/components/forms/manage/steps/UpdatePlanStep.tsx
@@ -54,7 +54,7 @@ export default function UpdatePlanStep({ user, onBack, onSuccess, onError }: Upd
         "/api/manage/purchase",
         {
           product_id: productId,
-          subscription_id: currentSubscription.subscription_id,
+          subscription_id: currentSubscription.subscriptionId,
         },
         {
           headers: {
@@ -168,7 +168,7 @@ export default function UpdatePlanStep({ user, onBack, onSuccess, onError }: Upd
   const availablePlans = products.filter(
     (p: Product) =>
       p.product_type === "subscription" &&
-      Number(p.product_id) !== Number(currentSubscription.product_id) &&
+      Number(p.product_id) !== Number(currentSubscription.productId) &&
       !isProductFree(p)
   )
 

--- a/types/api.ts
+++ b/types/api.ts
@@ -22,13 +22,16 @@ export interface User {
 }
 
 export interface Subscription {
-  subscription_id: number
-  subscription_name: string
-  product_id: number | string
-  renewal_cost: number
+  subscriptionId: number
+  userId?: number | null
+  subscriptionName: string
+  productId: number | string
+  amount: number
   duration?: string
   createdAt?: string
-  renewal_date?: string
+  renewalDate?: string | null
+  cancelOnRenewal?: boolean
+  downgradeOnRenewal?: boolean
   status?: string
   data: {
     renewal_cost: number


### PR DESCRIPTION
**Zoho Desk ticket:** [#1514](https://desk.zoho.com/support/dbmgrow/ShowHomePage.do#Cases/dv/1003209000009718001) — "ISSUE: 21 Users product getting an error"

## Summary
When a user tried to switch plans (e.g. to the "21 Agents"/"21 Users" product), the change failed with **"subscription_id is required"**, and there was no field in the UI to enter one — because the value is meant to be supplied automatically from the user's current subscription.

`GET /api/subscription/single` maps DB rows to **camelCase** (`subscriptionId`, `productId`) in `get-subscriptions.use-case.ts`, but `UpdatePlanStep.tsx` read them as **snake_case** (`currentSubscription.subscription_id`, `.product_id`). Those reads resolved to `undefined`, so axios dropped `subscription_id` from the `POST /api/manage/purchase` body, and the handler rejected it (`api/routes/manage/routes.ts`, "subscription_id is required").

## Root cause
- camelCase API response vs. snake_case field reads in the plan-change step, made invisible by a `Subscription` type (`types/api.ts`) that incorrectly declared snake_case fields.

## Changes
- `components/forms/manage/steps/UpdatePlanStep.tsx`: read `currentSubscription.subscriptionId` (sent to `manage/purchase`) and `currentSubscription.productId` (used to exclude the current plan from the selectable list).
- `types/api.ts`: correct the `Subscription` interface to match the real API contract (camelCase: `subscriptionId`, `userId`, `subscriptionName`, `productId`, `amount`, `renewalDate`, `cancelOnRenewal`, `downgradeOnRenewal`).

## Verification
- `yarn typecheck:next`: my change introduces **zero** new type errors. There are 3 pre-existing, unrelated failures (fumadocs `PageData` typing in `app/docs/*` and the ungenerated `@/.source/server` module) — confirmed **identical** on a clean baseline with my edits stashed.
- `yarn vitest run --config vitest.config.api.ts api/use-cases/subscription/get-subscriptions.use-case.test.ts`: **10/10 pass**, confirming the camelCase mapping (`subscriptionId`/`productId`) this fix relies on.
- No e2e/integration runs (sandbox has no DB/browser access).

## Notes
- The "21 Agents"/"21 Users" product was not found in seed data (highest seen is "16 Agents"); the bug itself is generic to any plan change and not specific to that product.

_Auto-opened as a DRAFT by /fix-urgent-ticket. Requires human testing and review before merge; never auto-merged._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fz3J5FWUtVzeB1a1UY7Hfv)_