### PR TITLE
#1053 Require first and last name at signup

### DIFF
--- a/api/use-cases/types/validation.schemas.ts
+++ b/api/use-cases/types/validation.schemas.ts
@@ -207,7 +207,13 @@ export const NewUserPurchaseInputSchema = z.object({
   expMonth: z.number().int().min(1).max(12).optional().nullable(),
   expYear: z.number().int().optional().nullable(),
   cardholderName: z.string().min(1, "Cardholder name is required").optional().nullable(),
-  name: z.string().optional().nullable(),
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .refine((value) => value.split(/\s+/).filter(Boolean).length >= 2, {
+      message: "Please enter your first and last name",
+    }),
   nameBroker: z.string().optional().nullable(),
   nameTeam: z.string().optional().nullable(),
   whitelabel: z.string().optional().nullable(),

--- a/components/forms/subscribe/SubscribeFlow.tsx
+++ b/components/forms/subscribe/SubscribeFlow.tsx
@@ -41,7 +41,12 @@ const cardDataSchema = z.object({
 const subscribeSchema = z.object({
   product: z.union([z.number(), z.literal("free"), z.literal("freeinvestor")]),
   email: z.string().email(),
-  name: z.string().min(2),
+  name: z
+    .string()
+    .min(2)
+    .refine((value) => value.trim().split(/\s+/).filter(Boolean).length >= 2, {
+      message: "Please enter your first and last name",
+    }),
   phone: z.string().min(10),
   slug: z.string().nullable(),
   name_broker: z.string().nullable(),

--- a/components/forms/subscribe/steps/NameStep.tsx
+++ b/components/forms/subscribe/steps/NameStep.tsx
@@ -18,7 +18,8 @@ interface NameStepProps {
 export default function NameStep({ form, onNext, onBack, setAllowReset }: NameStepProps) {
   const [isLoading, setIsLoading] = useState(false)
   const name = form.watch("name")
-  const isDisabled = !name || name.length < 2
+  const isFullName = (name ?? "").trim().split(/\s+/).filter(Boolean).length >= 2
+  const isDisabled = !isFullName
 
   const { currentWhitelabel } = useWhitelabel()
   const { getProductById } = useProducts({
@@ -56,14 +57,19 @@ export default function NameStep({ form, onNext, onBack, setAllowReset }: NameSt
   }
 
   return (
-    <Input
-      placeholder="John Doe"
-      name="name"
-      value={name}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) => form.setValue("name", e.target.value)}
-      isDisabled={isDisabled}
-      isLoading={isLoading}
-      handleSubmit={handleSubmit}
-    />
+    <>
+      <Input
+        placeholder="John Doe"
+        name="name"
+        value={name}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => form.setValue("name", e.target.value)}
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+        handleSubmit={handleSubmit}
+      />
+      {name && !isFullName ? (
+        <p className="mt-2 text-sm text-default-400">Please enter your first and last name.</p>
+      ) : null}
+    </>
   )
 }


### PR DESCRIPTION
**Zoho Desk ticket:** [#1053](https://desk.zoho.com/support/dbmgrow/ShowHomePage.do#Cases/dv/1003209000006514005) — "AGENTS ARE ABLE TO SIGN UP FOR SYSTEM WITHOUT ADDING LAST NAME"

## Summary
Agents were signing up with only a first name. The system uses a single "name" field (not separate first/last), and the only validation was a length check, so a single word (or even an email fallback) was accepted. Per the customer's own suggestion in the ticket ("check to make sure their name has a space in it"), this requires a full name (first + last) at signup.

Changes (all in this repo, so it holds for KW, YHS, and Instant Offers, which all funnel through this signup/purchase flow):
- **`components/forms/subscribe/steps/NameStep.tsx`** — the Next button now stays disabled until a first and last name are entered, with an inline "Please enter your first and last name." hint.
- **`components/forms/subscribe/SubscribeFlow.tsx`** — the submit-time `subscribeSchema` `name` field now requires two name parts.
- **`api/use-cases/types/validation.schemas.ts`** — server-side enforcement: `NewUserPurchaseInputSchema.name` requires a full name, so `POST /purchase/new` rejects a missing/single-word name (before any payment) regardless of client.

The "full name" rule is consistent across all three: after trimming, the name must contain at least two whitespace-separated parts.

## Root cause
The signup name field validated length only (`z.string().min(2)` on the form, `optional().nullable()` server-side), with a `v.name || v.cardholderName || v.email` fallback — so an agent entering just a first name (or nothing) produced an account with no last name.

## Verification
- API typecheck (`tsc -p api/tsconfig.json`) and Next typecheck (`tsc -p tsconfig.json`) — changed files are clean. (Two pre-existing, unrelated errors remain: `api/tests/integration/renewal-homeuptick-tiers.test.ts` and `lib/source.ts`; both fail on the base branch too.)
- The `usePurchase` unit test fails identically on the clean tree (a pre-existing jsdom/mock timeout), so it is unaffected by this change. Integration tests were not run (no DB access from the sandbox).

## Notes / out of scope
- KW signups originate on kwofferings.com (WordPress). This PR enforces the rule server-side at `POST /purchase/new`, which the KW checkout flows through, so KW signups are covered at the API boundary even though the WordPress form itself lives outside this repo.
- Mononyms (single legal names) will now be rejected at signup — this matches the ticket's explicit request to require a last name.

## Postmortem (draft — confirm & record via `/postmortem #1053`)
- **Introduced at:** implementation (missing full-name validation on the signup name field)
- **Should've been caught at:** tests (no test asserting the signup name requires a last name)
- **Introducing change:** unknown (predates traced history for the signup name field)
- **Countermeasure:** a unit test on `NewUserPurchaseInputSchema` asserting single-word names are rejected and full names accepted

_Auto-opened as a DRAFT by /fix-urgent-ticket. Requires human testing and review before merge; never auto-merged._

---
_Generated by [Claude Code](https://claude.ai/code/session_015gvKANAw3qkJKxZxf45aiV)_