### PR TITLE
refactor(CO-I130): repoint all v1 API callers to v2 ahead of v1 retirement

### DIFF
--- a/api/infrastructure/external-api/user-api/user-api.client.test.ts
+++ b/api/infrastructure/external-api/user-api/user-api.client.test.ts
@@ -23,7 +23,7 @@ function makeLogger(): ILogger {
 }
 
 function makeConfig(): IConfig {
-  return { api: { url: "https://api.test", masterToken: "tok" } } as unknown as IConfig
+  return { api: { url: "https://api.test", urlV2: "https://api.test/v2", masterToken: "tok" } } as unknown as IConfig
 }
 
 function userResponse(overrides: Record<string, unknown>) {

--- a/api/infrastructure/external-api/user-api/user-api.client.ts
+++ b/api/infrastructure/external-api/user-api/user-api.client.ts
@@ -15,7 +15,7 @@ export class UserApiClient implements IUserApiClient {
     private logger: ILogger
   ) {
     this.logger.debug("User API client initialized", {
-      apiUrl: config.api.url,
+      apiUrl: config.api.urlV2,
     })
   }
 
@@ -46,7 +46,7 @@ export class UserApiClient implements IUserApiClient {
 
       const response = await this.withRetry(
         () =>
-          axios.get(`${this.config.api.url}/users/${userId}`, {
+          axios.get(`${this.config.api.urlV2}/users/${userId}`, {
             headers: {
               "x-api-token": this.config.api.masterToken,
             },
@@ -84,9 +84,12 @@ export class UserApiClient implements IUserApiClient {
     try {
       this.logger.debug("Fetching user by email from API", { email })
 
+      // v2 has no exact `?email=` filter; its list search (`search_terms`) LIKE-matches
+      // name/email/phone, so search then pick the exact email match and re-fetch the
+      // full record (the list projection may omit fields parseUser needs).
       const response = await this.withRetry(
         () =>
-          axios.get(`${this.config.api.url}/users?email=${encodeURIComponent(email)}`, {
+          axios.get(`${this.config.api.urlV2}/users?search_terms=${encodeURIComponent(email)}&limit=20`, {
             headers: {
               "x-api-token": this.config.api.masterToken,
             },
@@ -98,9 +101,12 @@ export class UserApiClient implements IUserApiClient {
       const data: any = response.data
       const duration = Date.now() - startTime
 
-      if (data.success === "success" && data.data && data.data.length > 0) {
-        this.logger.debug("User found by email", { email, duration })
-        return this.parseUser(data.data[0])
+      if (data.success === "success" && Array.isArray(data.data)) {
+        const match = data.data.find((u: any) => typeof u.email === "string" && u.email.toLowerCase() === email.toLowerCase())
+        if (match) {
+          this.logger.debug("User found by email", { email, duration })
+          return this.getUser(match.user_id || match.id)
+        }
       }
 
       this.logger.debug("User not found by email", { email, duration })
@@ -120,7 +126,7 @@ export class UserApiClient implements IUserApiClient {
 
       // POST is not idempotent: a timeout-then-retry could create a duplicate
       // user if the origin processed the first request. Use a timeout but no retry.
-      const response = await axios.post(`${this.config.api.url}/users`, userData, {
+      const response = await axios.post(`${this.config.api.urlV2}/users`, userData, {
         headers: {
           "Content-Type": "application/json",
           "x-api-token": this.config.api.masterToken,
@@ -187,7 +193,7 @@ export class UserApiClient implements IUserApiClient {
 
       const response = await this.withRetry(
         () =>
-          axios.put(`${this.config.api.url}/users/${userId}`, body, {
+          axios.put(`${this.config.api.urlV2}/users/${userId}`, body, {
             headers: {
               "Content-Type": "application/json",
               "x-api-token": this.config.api.masterToken,
@@ -202,7 +208,14 @@ export class UserApiClient implements IUserApiClient {
 
       this.logger.debug("User updated successfully", { userId, duration })
 
-      return this.parseUserResponse(data)
+      // v2's PUT /users/:id returns an empty data object (no user payload). Parse
+      // the response when it does carry a user; otherwise re-fetch for the caller.
+      if (data?.success === "success" && data.data && (data.data.user_id || data.data.id)) {
+        return this.parseUser(data.data)
+      }
+      const updated = await this.getUser(userId)
+      if (!updated) throw new Error(`User ${userId} updated but could not be re-fetched`)
+      return updated
     } catch (error) {
       const duration = Date.now() - startTime
       const responseData = (error as any)?.response?.data
@@ -330,7 +343,7 @@ export class UserApiClient implements IUserApiClient {
       this.logger.info("Creating team via API", { teamname: params.teamname, ownerId: params.owner_id })
 
       // POST is not idempotent: no retry, to avoid creating a duplicate team.
-      const response = await axios.post(`${this.config.api.url}/teams`, params, {
+      const response = await axios.post(`${this.config.api.urlV2}/teams`, params, {
         headers: {
           "Content-Type": "application/json",
           "x-api-token": this.config.api.masterToken,

--- a/api/lib/services.ts
+++ b/api/lib/services.ts
@@ -141,6 +141,7 @@ eventBus.subscribe("SubscriptionCancelled", homeUptickAccountHandler)
 // Map env-style keys to their nested config paths
 const configKeyMap: Record<string, () => unknown> = {
   API_URL: () => config.api.url,
+  API_URL_V2: () => config.api.urlV2,
   API_MASTER_TOKEN: () => config.api.masterToken,
   API_KEY: () => config.api.key,
   ADMIN_EMAIL: () => config.adminEmail,

--- a/api/routes/auth/routes.ts
+++ b/api/routes/auth/routes.ts
@@ -21,7 +21,7 @@ app.openapi(LoginRoute, async (c) => {
 
     // Proxy login request to V2 auth API
     const response = await axios.post(
-      `${config.api.url}/auth/login`,
+      `${config.api.urlV2}/auth/login`,
       { email, password },
       {
         validateStatus: () => true, // Don't throw on any status code

--- a/api/routes/manage/routes.ts
+++ b/api/routes/manage/routes.ts
@@ -124,26 +124,24 @@ app.openapi(CheckTokenRoute, async (c) => {
       throw new Error("Token not valid")
     }
 
-    // Fetch user details
-    const url = `${config.api.url}/users/${decoded.id}`
-    const userResponse = await fetch(url, {
-      headers: {
-        "x-api-token": config.api.key,
-      },
-    })
+    // Resolve the user directly from the DB (billing already reads Users for the
+    // token flows — see getUserFromToken). The old path fetched v1's
+    // GET /users/:id for its `_api_token` field, which v2 does not expose.
+    const userRow: any = await db
+      .selectFrom("Users")
+      .selectAll()
+      .where("user_id", "=", decoded.id)
+      .executeTakeFirst()
 
-    const user: any = await userResponse.json()
-
-    if (user?.success !== "success") {
-      throw new Error("Error fetching user")
-    }
-
-    if (!user?.data) {
+    if (!userRow) {
       throw new Error("User not found")
     }
 
+    const { password: _password, api_token, ...safeUser } = userRow
+    const user = { data: { ...safeUser, _api_token: api_token } }
+
     // Get API token from user data
-    const apiToken = user.data._api_token
+    const apiToken = api_token
 
     // Set authentication cookie
     if (apiToken) {

--- a/api/routes/signup/routes.ts
+++ b/api/routes/signup/routes.ts
@@ -126,19 +126,22 @@ app.openapi(CheckSlugExistsRoute, async (c) => {
   try {
     const { slug } = c.req.valid("param")
 
+    // v2 responds 200 {exists:false} when the slug is free and 400 (CodedError)
+    // when it's taken — treat the 400 as "exists" rather than an error.
     const response = await axios.get(
-      `${config.api.url}/client-site/checkslugexists/${encodeURIComponent(slug)}`,
+      `${config.api.urlV2}/client-site/checkslugexists/${encodeURIComponent(slug)}`,
       {
         headers: {
           "x-api-token": config.api.key,
         },
+        validateStatus: (status) => status < 500,
       }
     )
 
     const json = response.data
     const data = json?.data
 
-    if (data?.exists === false) {
+    if (response.status === 200 && data?.exists === false) {
       return c.json(
         {
           success: "success" as const,

--- a/api/use-cases/property/unlock-property.use-case.ts
+++ b/api/use-cases/property/unlock-property.use-case.ts
@@ -252,7 +252,7 @@ export class UnlockPropertyUseCase implements IUnlockPropertyUseCase {
   }
 
   private async fetchProperty(propertyToken: string): Promise<any> {
-    const apiUrl = this.deps.config.get("API_URL")
+    const apiUrl = this.deps.config.get("API_URL_V2")
     const apiToken = this.deps.config.get("API_MASTER_TOKEN")
 
     try {
@@ -277,7 +277,7 @@ export class UnlockPropertyUseCase implements IUnlockPropertyUseCase {
   }
 
   private async updateProperty(propertyToken: string): Promise<void> {
-    const apiUrl = this.deps.config.get("API_URL")
+    const apiUrl = this.deps.config.get("API_URL_V2")
     const apiToken = this.deps.config.get("API_MASTER_TOKEN")
 
     try {

--- a/docs/CO-I130-v1-repoint-status.md
+++ b/docs/CO-I130-v1-repoint-status.md
@@ -1,0 +1,34 @@
+# CO-I130 — Billing v1→v2 API Repoint (status)
+
+**PR:** [#30](https://github.com/DBMGrow/cashoffers-billing/pull/30) (draft) · `refactor/CO-I130-billing-v1-to-v2-repoint` → `staging`
+**Last updated:** 2026-07-09 by Gab
+**Parent effort:** CashOffers v1 decommission (CO-I130). The team-wide rollup lives in the monorepo — [`docs/plans/v2-migration-status-board.md`](https://github.com/DBMGrow/cashoffers-dashboard-mono/blob/staging/docs/plans/v2-migration-status-board.md) (§4, "Real-user /api/v1 tail" row) — this file only tracks the billing side. Full Q&A rationale: monorepo [`docs/questions/CO-I130-billing-v1-repoint-questions.md`](https://github.com/DBMGrow/cashoffers-dashboard-mono/blob/staging/docs/questions/CO-I130-billing-v1-repoint-questions.md).
+
+## Why (one paragraph)
+
+Billing's user/team/property calls still hit the **v1** API (`API_URL`); prod logs identified billing's service identity (user id 2) in the v1 traffic tail. v1 is being retired, and — sooner — monorepo PR #669 deletes the internal bridge those v1 calls depend on, which would **silently break premium activation**. This PR moves all six remaining call sites to v2 (`API_URL_V2`, already present in every env — zero env changes).
+
+## Status checklist
+
+- [x] Six v1 call sites identified (user-api client ×5 ops, auth login, signup slug check, manage/checktoken, unlock-property ×2) — 2026-07-09
+- [x] Fix implemented incl. 3 v1↔v2 contract adaptations (no `?email=` filter on v2 → search+exact-match; taken slug = 400; `_api_token` not exposed → DB lookup) — 2026-07-09
+- [x] `tsc` clean · 14/14 tests pass — 2026-07-09
+- [x] **Live A/B/A verified locally** — with fix, requests observed landing on local api-v2; with old code, zero local hits (went remote) — 2026-07-09
+- [x] Draft PR #30 opened → `staging` — 2026-07-09
+- [ ] Team review → mark ready → merge
+- [ ] Deploy billing (staging first: run a signup, an SSO link if any exist, a premium toggle)
+- [ ] **Prod verification:** user-2 traffic disappears from v1 logs / `INTERNAL_API` count (key holder query, monorepo tracker §6)
+- [ ] Later cleanup (separate PR): remove `API_URL` from required env vars once nothing references it
+
+## Ordering constraint
+
+⚠️ **Merge + deploy this PR before monorepo PR #669 is promoted to `main`.** #669 removes the v1→v2 bridge receivers; billing's current v1 calls transit that bridge, and v1 does not check the bridge response — failures would be silent (customer pays, premium never applies).
+
+## Endpoint usage notes (verified 2026-07-09)
+
+| Call | Live? |
+|---|---|
+| `updateUser` / `getUser` | **Core traffic** — premium lifecycle (account + webhook + purchase handlers) |
+| signup slug check | Live — signup flow slug step |
+| `getUserByEmail` | Dead code (no production callers); fixed defensively |
+| `manage/checktoken` | Dormant — no link generator exists anymore; serves old links only |


### PR DESCRIPTION
## Why

CO-I130 (v1 decommission) prod verification showed **user id 2 — this billing service's API identity — still calling the v1 API** (part of the "~4% real-user v1 tail"). Six call sites here still use `API_URL` (v1). This blocks v1 retirement three ways:

1. **Phase 4 deletes v1** — these calls would hit a dead server (premium activation, signup team creation, SSO login, property unlock all break).
2. **The 7-day bridge-idle monitor can never pass** — v1's `users.php`/`teams.php` are hollowed shells that forward every one of these calls through `Internal::v2Request`, so billing traffic keeps the `INTERNAL_API` counter nonzero.
3. **Soonest: monorepo PR #669** (merged to its `staging`) deletes the `/webhook/internal/user/*` + `/webhook/internal/teams/*` bridge targets. Once promoted, billing's premium updates would fail **silently** (v1 doesn't check the bridge response) — this PR must deploy first.

## What

Repoint all six call sites to `config.api.urlV2` (already defined in every environment — **no env changes needed**), handling three v1↔v2 contract differences:

| Call site | Change |
|---|---|
| `user-api.client.ts` (get/create/update user, create team) | URL swap + `getUserByEmail` rewritten: v2 has no `?email=` filter, so use `search_terms` + exact-match + full re-fetch (a naive swap silently returns the **wrong user**). `updateUser` re-fetches when the response has no user body (v2's PUT returns `{}`). |
| `routes/auth/routes.ts` login proxy | URL swap (the comment always said "V2"). |
| `routes/signup/routes.ts` slug check | URL swap + map v2's 400 (slug taken) to `userExists: true` instead of an error. |
| `routes/manage/routes.ts` checktoken (SSO) | Resolve user + `api_token` **directly from the DB** (same pattern as `getApiTokenByEmail`) — v2 doesn't expose `_api_token`. Response shape preserved. |
| `use-cases/property/unlock-property.use-case.ts` | URL swap ×2 (v2 `getPropertyID` accepts property tokens). |
| `lib/services.ts` | Add `API_URL_V2` to the configService key map. |

The #1494 integration-managed-premium guard is untouched and its tests still pass.

## Verification

- `tsc --noEmit` clean
- 14/14 tests across `external-api/` + `use-cases/property/` pass
- Suggested staging check before merge: run a signup, an SSO login link, and a premium toggle against staging; then confirm user-2 traffic disappears from the v1 logs

## Context docs

Monorepo: `docs/plans/v2-migration-status-board.md` §4 ("Real-user /api/v1 tail" row) · `docs/plans/v2-migration-decommission-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)