### PR TITLE
#1053 Require first and last name on new-user signup

### DIFF
--- a/api/routes/purchase/schemas.ts
+++ b/api/routes/purchase/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { ErrorResponseSchema, EmailSchema } from "../helpers/common.schemas"
+import { isFullName, FULL_NAME_REQUIRED_MESSAGE } from "@api/utils/full-name"
 
 /**
  * Purchase route schemas
@@ -20,7 +21,7 @@ export const NewUserPurchaseRequestSchema = z.object({
   exp_month: z.union([z.string(), z.number()]).optional().nullable(),
   exp_year: z.union([z.string(), z.number()]).optional().nullable(),
   cardholder_name: z.string().optional().nullable(),
-  name: z.string().optional().nullable(),
+  name: z.string().refine(isFullName, { message: FULL_NAME_REQUIRED_MESSAGE }),
   name_broker: z.string().optional().nullable(),
   name_team: z.string().optional().nullable(),
   whitelabel: z.string().optional().nullable(),

--- a/api/use-cases/types/validation.schemas.ts
+++ b/api/use-cases/types/validation.schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { isFullName, FULL_NAME_REQUIRED_MESSAGE } from "@api/utils/full-name"
 
 /**
  * Zod validation schemas for use case inputs
@@ -207,7 +208,7 @@ export const NewUserPurchaseInputSchema = z.object({
   expMonth: z.number().int().min(1).max(12).optional().nullable(),
   expYear: z.number().int().optional().nullable(),
   cardholderName: z.string().min(1, "Cardholder name is required").optional().nullable(),
-  name: z.string().optional().nullable(),
+  name: z.string().refine(isFullName, { message: FULL_NAME_REQUIRED_MESSAGE }),
   nameBroker: z.string().optional().nullable(),
   nameTeam: z.string().optional().nullable(),
   whitelabel: z.string().optional().nullable(),

--- a/api/utils/full-name.test.ts
+++ b/api/utils/full-name.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest"
+import { isFullName } from "./full-name"
+import { NewUserPurchaseInputSchema } from "@api/use-cases/types/validation.schemas"
+
+describe("isFullName", () => {
+  it("accepts a first and last name", () => {
+    expect(isFullName("John Doe")).toBe(true)
+    expect(isFullName("Mary Jane Watson")).toBe(true)
+    expect(isFullName("  John   Doe  ")).toBe(true)
+  })
+
+  it("rejects a single name, empty, or whitespace-only", () => {
+    expect(isFullName("John")).toBe(false)
+    expect(isFullName("John ")).toBe(false)
+    expect(isFullName("")).toBe(false)
+    expect(isFullName("   ")).toBe(false)
+    expect(isFullName(null)).toBe(false)
+    expect(isFullName(undefined)).toBe(false)
+  })
+})
+
+describe("NewUserPurchaseInputSchema name validation", () => {
+  const base = { productId: 1, email: "agent@example.com", phone: "+15551234567" }
+
+  it("rejects a signup whose name has no last name (ticket #1053)", () => {
+    const result = NewUserPurchaseInputSchema.safeParse({ ...base, name: "John" })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects a signup with a missing name", () => {
+    const result = NewUserPurchaseInputSchema.safeParse({ ...base })
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts a signup with a first and last name", () => {
+    const result = NewUserPurchaseInputSchema.safeParse({ ...base, name: "John Doe" })
+    expect(result.success).toBe(true)
+  })
+})

--- a/api/utils/full-name.ts
+++ b/api/utils/full-name.ts
@@ -1,0 +1,14 @@
+/**
+ * Full-name validation for signup.
+ *
+ * Signups collect a single free-text "name" field which downstream code splits
+ * on whitespace into first/last name. A name without a space yields an empty
+ * last name, so we require at least a first and last name (two whitespace-
+ * separated, non-empty parts).
+ */
+export const FULL_NAME_REQUIRED_MESSAGE = "Please enter your first and last name"
+
+export function isFullName(name: string | null | undefined): boolean {
+  if (!name) return false
+  return name.trim().split(/\s+/).filter(Boolean).length >= 2
+}

--- a/docs/system/data-flows/purchase-flow.md
+++ b/docs/system/data-flows/purchase-flow.md
@@ -42,6 +42,15 @@ sequenceDiagram
   API->>DB: Create Homeuptick_Subscriptions row (from product template or defaults)
 ```
 
+### Input validation
+
+The `name` field must be a full name — a first and last name (at least two
+whitespace-separated parts). Downstream provisioning splits `name` on whitespace
+into first/last name, so a single-word name produces an empty last name. Signups
+without a last name are rejected up front (before any card is created or charged)
+with `PURCHASE_VALIDATION_ERROR` → HTTP 400. Enforced in both the route request
+schema and the use-case schema via `isFullName` (`api/utils/full-name.ts`).
+
 ### Error Handling After Payment
 
 | Failure point | Refund? | Action |


### PR DESCRIPTION
**Zoho Desk ticket:** [#1053](https://desk.zoho.com/support/dbmgrow/ShowHomePage.do#Cases/dv/1003209000006514005) — "AGENTS ARE ABLE TO SIGN UP FOR SYSTEM WITHOUT ADDING LAST NAME"

## Summary
- New-user signups (`POST /purchase/new`) collect a single free-text `name` field. Provisioning later splits that name on whitespace into first/last name (`user-api.client.ts` → `name?.split(" ")[1]`), so a single-word name (e.g. "Annette") is created with an **empty last name**.
- This change requires `name` to be a full name — at least two whitespace-separated, non-empty parts — enforced in **both** validation layers of the endpoint:
  - the route request schema (`api/routes/purchase/schemas.ts`) → clean HTTP 400 with a field message, and keeps the OpenAPI contract accurate;
  - the use-case schema (`api/use-cases/types/validation.schemas.ts`) → the domain guarantee, rejecting with `PURCHASE_VALIDATION_ERROR` (→ 400).
- Rejection happens **before any card is created or charged** (validation is the first step of the use case), so no payment is taken on a rejected signup.
- Shared rule lives in `api/utils/full-name.ts` (`isFullName` + message), imported by both layers (neutral util — no cross-layer dependency). Covers every signup channel that funnels through `/purchase/new` (KW / kwofferings.com, YHS, Instant Offers), as the ticket requested.
- Added unit tests (`api/utils/full-name.test.ts`) and a note in `docs/system/data-flows/purchase-flow.md`.

## Root cause
- The signup name field had no first/last-name validation (`name` was `optional().nullable()`), while downstream provisioning assumes `name` contains a space to derive the last name.

## Verification
- `yarn typecheck:api` — clean for all touched files (one **pre-existing, unrelated** error remains in `api/tests/integration/renewal-homeuptick-tiers.test.ts`, confirmed present on `main` without this change).
- New unit tests pass (5/5). Full `api/use-cases` unit run: the only failures are 3 **pre-existing, unrelated** tests in `create-subscription`/`renew-subscription` (confirmed present on `main`).
- Integration/e2e signup tests were **not** run (no DB access in the auto-fixer sandbox); their existing fixtures already use full names.

## Postmortem (draft — confirm & record via `/postmortem #1053`)
- **Introduced at:** spec (signup contract never specified a first+last name requirement)
- **Should've been caught at:** type_system / tests (input schema accepted a name that downstream code assumed contained a space)
- **Introducing change:** unknown (predates the name-splitting provisioning logic)
- **Countermeasure:** shared `isFullName` validator enforced at both the route and use-case boundary, with unit coverage, so the "name has no last name" class of bug is rejected at the edge

_Auto-opened as a DRAFT by /fix-urgent-ticket. Requires human testing and review before merge; never auto-merged._

---
_Generated by [Claude Code](https://claude.ai/code/session_01USEE6YZe8uLvR5XFiEV74Y)_